### PR TITLE
Add a bash file which helps to download the model checkpoints with gdown tool

### DIFF
--- a/scripts/gdown_download_checkpoints.sh
+++ b/scripts/gdown_download_checkpoints.sh
@@ -4,6 +4,8 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 mkdir -p $SCRIPT_DIR/../checkpoints
 
+#TODO: we can download the checkpoints with gdown tool, sometimes it is hard to use the gcloud tool
+
 pip install gdown
 pip install --upgrade gdown
 

--- a/scripts/gdown_download_checkpoints.sh
+++ b/scripts/gdown_download_checkpoints.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+mkdir -p $SCRIPT_DIR/../checkpoints
+
+pip install gdown
+pip install --upgrade gdown
+
+wget https://huggingface.co/stabilityai/stable-diffusion-2-1-base/resolve/main/v2-1_512-ema-pruned.ckpt $SCRIPT_DIR/../checkpoints/v2-1_512-ema-pruned.ckpt
+
+gdown https://storage.googleapis.com/sfr-hive-data-research/checkpoints/hive_rw_condition.ckpt -O $SCRIPT_DIR/../checkpoints/hive_rw_condition.ckpt
+gdown https://storage.googleapis.com/sfr-hive-data-research/checkpoints/hive_v2_rw_condition.ckpt -O $SCRIPT_DIR/../checkpoints/hive_v2_rw_condition.ckpt
+gdown https://storage.googleapis.com/sfr-hive-data-research/checkpoints/hive_rw.ckpt -O $SCRIPT_DIR/../checkpoints/hive_rw.ckpt
+gdown https://storage.googleapis.com/sfr-hive-data-research/checkpoints/hive_v2_rw.ckpt -O $SCRIPT_DIR/../checkpoints/hive_v2_rw.ckpt
+
+
+#gcloud storage cp gs://sfr-hive-data-research/checkpoints/hive_rw_condition.ckpt $SCRIPT_DIR/../checkpoints/hive_rw_condition.ckpt
+#gcloud storage cp gs://sfr-hive-data-research/checkpoints/hive_v2_rw_condition.ckpt $SCRIPT_DIR/../checkpoints/hive_v2_rw_condition.ckpt
+#gcloud storage cp gs://sfr-hive-data-research/checkpoints/hive_rw.ckpt $SCRIPT_DIR/../checkpoints/hive_rw.ckpt
+#gcloud storage cp gs://sfr-hive-data-research/checkpoints/hive_v2_rw.ckpt $SCRIPT_DIR/../checkpoints/hive_v2_rw.ckpt


### PR DESCRIPTION
Sometimes it is hard to install the google cloud download tool (gcloud). I provide a bash file which uses pip to install `gdown` package and then use `gdown` to download the model checkpoints. I validate this bash file on my personal Ubuntu server and it works.

-------

I've signed the salesforce Contributor license agreement after the initial PR.